### PR TITLE
fix: problem where when cloning the project it was not possible to run

### DIFF
--- a/examples/kitchen-sink/package.json
+++ b/examples/kitchen-sink/package.json
@@ -3,7 +3,7 @@
   "scripts": {
     "build": "turbo build",
     "clean": "turbo clean",
-    "dev": "turbo dev --no-cache  --continue",
+    "dev": "turbo dev --no-cache --continue --concurrency 11",
     "format": "prettier --write \"**/*.{ts,tsx,md}\"",
     "lint": "turbo lint",
     "test": "turbo test"


### PR DESCRIPTION

### Description

due to changes in the repository, the number of projects has increased. soon after cloning the repository and running locally, the person already receives this error. to fix it without removing any package just add concurrency to 11 in the main command

### How to get the error that this Pr fixes

- npx create-turbo -e kitchen-sink
- npm run dev

Get this error:
```bash
❯ npm run dev

> dev
> turbo dev --no-cache  --continue

 ERROR  run failed: error preparing engine: Invalid persistent task configuration:
You have 10 persistent tasks but `turbo` is configured for concurrency of 10. Set --concurrency to at least 11
```

### issues: #4291
